### PR TITLE
remove version specification from compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   ad-fontem:
     container_name: ad-fontem


### PR DESCRIPTION
This pull request makes a small change to the `compose.yml` file, removing the `version: '3.8'` line. This update aligns with newer Docker Compose recommendations, as the version field is now optional and often unnecessary.