### PR TITLE
fix: standardize container name and image references in compose files

### DIFF
--- a/compose.build.yml
+++ b/compose.build.yml
@@ -3,8 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: ad-fontem
-    image: zbejas/ad-fontem:latest
+    container_name: ad_fontem
     restart: unless-stopped
     env_file:
       - .env

--- a/compose.yml
+++ b/compose.yml
@@ -1,10 +1,10 @@
 services:
   ad-fontem:
-    container_name: ad-fontem
-    image: zbejas/ad-fontem:latest
+    container_name: ad_fontem
+    image: zbejas/ad_fontem:latest
     restart: unless-stopped
     env_file:
-      - fileName: .env
+      - .env
     #environment:
     #  - DISCORD_BOT_TOKEN=abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
     #  - YOUTUBE_API_KEY=cba0987654321fedcba0987654321fedcba0987654321fedcba0987654321fedcba


### PR DESCRIPTION
This pull request updates the Docker Compose configuration files to standardize naming conventions and correct file references. The main focus is on ensuring consistency between the compose files and aligning with best practices for container and image naming.

Configuration and Naming Consistency:

* Changed the `container_name` from `ad-fontem` to `ad_fontem` in both `compose.yml` and `compose.build.yml` to use underscores instead of hyphens, ensuring consistent naming. [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L3-R7) [[2]](diffhunk://#diff-02f64f4db990f75996983ba4a153fcb863ae0c29d283185e4c14196a2e24c697L6-R6)
* Updated the `image` name from `zbejas/ad-fontem:latest` to `zbejas/ad_fontem:latest` in `compose.yml` for consistency with the new naming convention.
* Fixed the `env_file` reference in `compose.yml` by removing the unnecessary `fileName:` key and using the correct format.