### PR TITLE
Dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ YOUTUBE_API_KEY=your_youtube_api_key_here
 OLLAMA_ENABLED=false
 OLLAMA_URL=http://ollama:11434
 OLLAMA_MODEL=llama3.1:8b
-OLLAMA_PROMPT="Analyze the following text and return YouTube URLs that represent original content being reacted to or credited in reaction videos.
+OLLAMA_PROMPT="Analyze the following text and extract YouTube URLs that represent original content being reacted to or credited in reaction videos.
 
 EXCLUDE these types of sources:
 - Government channels, news videos, documentaries
@@ -21,12 +21,17 @@ EXCLUDE these types of sources:
 ONLY INCLUDE URLs when the text clearly indicates a reaction video format with phrases like:
 - 'reacts to' / 'reacting to' / 'reaction to'
 - 'watching' / 'responds to'
+- 'video by' / 'by'
+- 'full video' / 'full interview'
 - Similar reaction-specific language
 
-For normal video descriptions without clear reaction context, return None.
+IMPORTANT: You must respond with a valid JSON object containing a 'links' array. If no qualifying YouTube links are found, return an empty array.
 
-Return results in array format [link1, link2, ...] or None if no qualifying links are found.
-Only return a list or 'None' - no additional text or explanations."
+Examples:
+- If links found: {\"links\": [\"https://youtube.com/watch?v=abc123\", \"https://youtu.be/def456\"]}
+- If no links found: {\"links\": []}
+
+Do not include any additional text, explanations, or markdown formatting - only return the JSON object."
 
 # Set to true to skip regex matching and only use Ollama for link extraction
 # This is quite useful since regex matching can be unreliable for complex descriptions, and I am bad at writing regex

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ The application uses the following environment variables, which should be define
 |----------|-------------|---------|---------|
 | `DEBUG` | Enable verbose debug logging | `false` | `true` |
 | `OLLAMA_ENABLED` | Enable Ollama AI analysis | `false` | `true` |
-| `OLLAMA_URL` | Ollama server endpoint | `http://localhost:11434` | `http://ollama:11434` |
-| `OLLAMA_MODEL` | Ollama model to use | `llama3.1:8b` | `llama3.1:8b` |
+| `OLLAMA_URL` | Ollama server endpoint | `None` | `http://ollama:11434` |
+| `OLLAMA_MODEL` | Ollama model to use | `None` | `llama3.1:8b` |
 | `OLLAMA_ONLY` | Skip regex, use only AI analysis | `false` | `true` |
 | `OLLAMA_PROMPT` | Custom prompt for AI analysis | _(see .env.example)_ | _(custom prompt)_ |
 


### PR DESCRIPTION
This pull request improves the reliability and structure of extracting YouTube links using Ollama by enforcing a strict JSON response format, updating the prompt instructions, and enhancing the parsing logic to handle structured responses. It also updates documentation to reflect these changes.

**Prompt and API integration improvements:**

* The `OLLAMA_PROMPT` in `.env.example` now instructs Ollama to return a JSON object with a `links` array, and not to include any extra text or formatting. It also clarifies the inclusion criteria for links and provides concrete response examples. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL11-R11) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR24-R34)
* The Ollama API call in `extractLinksWithOllama` (`src/utils/youtube.ts`) now explicitly requests a JSON schema with a `links` array, ensuring the model's output is structured and predictable.

**Parsing and error handling enhancements:**

* The link extraction logic in `extractLinksWithOllama` has been updated to first attempt parsing the response as structured JSON, handle missing or empty `links` properties, and fall back to legacy parsing if needed. This increases robustness and backward compatibility. [[1]](diffhunk://#diff-23d4cc15c25a124c09ced72a01044bbe3ed8d146c8804699338084ea99137edaR200-R232) [[2]](diffhunk://#diff-23d4cc15c25a124c09ced72a01044bbe3ed8d146c8804699338084ea99137edaR269)

**Documentation updates:**

* The `README.md` has been updated to indicate that `OLLAMA_URL` and `OLLAMA_MODEL` now default to `None` if not set, reflecting the new configuration approach.